### PR TITLE
Reduce build requirement

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildPlugin(configurations: [
+buildPlugin(useContainerAgent: true, configurations: [
   [ platform: 'linux', jdk: '11' ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,3 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+  [ platform: 'linux', jdk: '11' ]
+])


### PR DESCRIPTION
The plugin is only a wrapper, has no test and compile nothing.
Because of this, there is no need (?) to build the plugin on windows and on linux and to valid the build on different JDK versions. 

So, only using linux and JDK 11 could speed up the CI process.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
